### PR TITLE
Update geovista dep on conda-forge

### DIFF
--- a/leap_hub_import_error.ipynb
+++ b/leap_hub_import_error.ipynb
@@ -7,8 +7,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!mamba install -c conda-forge vtk=*=osmesa* pyvista trame -y\n",
-    "!pip install geovista --no-deps"
+    "!mamba install -c conda-forge vtk=*=osmesa* pyvista geovista trame -y\n",
    ]
   }
  ],


### PR DESCRIPTION
Once https://github.com/conda-forge/geovista-feedstock/pull/11 lands, its safe to put geovista in the mamba install command